### PR TITLE
Allow Stylus module to be passed as option

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,22 @@ var outputTree = compileLess(inputTrees, inputFile, outputFile, options)
 
 * **`options`**: A hash of options for stylus.
 
+* **`options.module`**: Stylus module to use instead of the provided version.
+
 ### Example
 
 ```js
 var appCss = compileLess(sourceTrees, 'myapp/app.styl', 'assets/app.css')
+```
+
+### Using a specific Stylus version
+
+This plugin comes bundled with a recent version of Stylus, but you may want or need to use a specific version instead.
+
+Include `stylus` in your project's `package.json` and `require` it as the value for this plugin's `module` option.
+
+```js
+var appCss = compileLess(sourceTrees, 'myapp/app.styl', 'assets/app.css', {
+  module: require('stylus')
+});
 ```

--- a/index.js
+++ b/index.js
@@ -15,6 +15,8 @@ function StylusCompiler (sourceTrees, inputFile, outputFile, options) {
   this.inputFile = inputFile
   this.outputFile = outputFile
   this.stylusOptions = options || {}
+  this.stylus = this.stylusOptions.module || stylus
+  delete this.stylusOptions.module
 }
 
 StylusCompiler.prototype.read = function (readTree) {
@@ -33,7 +35,7 @@ StylusCompiler.prototype.read = function (readTree) {
       data = fs.readFileSync(stylusOptions.filename, 'utf8');
 
       var promise = new RSVP.Promise(function(resolve, reject) {
-        stylus.render(data, stylusOptions, function (e, css) {
+        self.stylus.render(data, stylusOptions, function (e, css) {
           if (e) {
             reject(e);
           }


### PR DESCRIPTION
Sometimes a specific Stylus version is desired that is different than the one bundled with this plugin. This allows Stylus to be passed as an option to the plugin.
#### Example

If I always want to use the latest pre-1.0 version of Stylus in my project...

In `package.json`:

``` json
{
  "name": "my-project",
  "dependencies": {
    "broccoli-stylus-single": "0.1.2",
    "stylus": "0.x",
    …
  }
}
```

In `Brocfile.js`:

``` js
var compileStylus = require('broccoli-stylus-single');
var stylus = require('stylus');

…

var outputTree = compileStylus(sourceTrees, 'myapp/app.styl', 'assets/app.css', {
  module: stylus
});
```
