### PR TITLE
Add Stylus as peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,20 @@ var outputTree = compileLess(inputTrees, inputFile, outputFile, options)
 ```js
 var appCss = compileLess(sourceTrees, 'myapp/app.styl', 'assets/app.css')
 ```
+
+### Stylus Version
+
+This plugin uses a recent Stylus version, but can utilize a specific version of your choice. To require a specific version simply specify it in your project's `package.json` along with this plugin.
+
+In this example `package.json`, the latest pre-1.0 version of Stylus will be used instead of the version bundled with this plugin:
+
+```json
+{
+  "name": "your-project",
+  "dependencies": {
+    "broccoli-stylus-single": "0.1.2",
+    "stylus": "0.x",
+    …
+  }
+}
+```

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "stylus": "~0.42.3",
     "rsvp": "~3.0.6"
   },
+  "peerDependencies": {
+    "stylus": "*"
+  },
   "readmeFilename": "README.md",
   "bugs": {
     "url": "https://github.com/gabrielgrant/broccoli-stylus-single/issues"


### PR DESCRIPTION
Sometimes a specific Stylus version is desired that is different than the one bundled with this plugin.
