### PR TITLE
Cache results from compilation to avoid unnecessary rebuilds.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,13 @@
-var fs = require('fs')
-var path = require('path')
-var mkdirp = require('mkdirp')
-var includePathSearcher = require('include-path-searcher')
-var quickTemp = require('quick-temp')
-var mapSeries = require('promise-map-series')
-var _ = require('lodash')
+var fs = require('fs');
+var path = require('path');
+var mkdirp = require('mkdirp');
+var includePathSearcher = require('include-path-searcher');
+var _ = require('lodash');
 var RSVP = require('rsvp');
+var CachingWriter = require('broccoli-caching-writer');
+
+StylusCompiler.prototype = Object.create(CachingWriter.prototype);
+StylusCompiler.prototype.constructor = StylusCompiler;
 
 // Use the stylus module in the root project if available;
 // otherwise, use the one included with this plugin
@@ -15,44 +17,36 @@ var stylus = requirePeer('stylus', { optional: true }) || require('stylus');
 
 module.exports = StylusCompiler
 function StylusCompiler (sourceTrees, inputFile, outputFile, options) {
-  if (!(this instanceof StylusCompiler)) return new StylusCompiler(sourceTrees, inputFile, outputFile, options)
-  this.sourceTrees = sourceTrees
-  this.inputFile = inputFile
-  this.outputFile = outputFile
-  this.stylusOptions = options || {}
+  if (!(this instanceof StylusCompiler)) return new StylusCompiler(sourceTrees, inputFile, outputFile, options);
+  CachingWriter.apply(this, arguments);
+  this.inputFile = inputFile;
+  this.outputFile = outputFile;
+  this.stylusOptions = options || {};
 }
 
-StylusCompiler.prototype.read = function (readTree) {
-  var self = this
-  quickTemp.makeOrRemake(this, '_tmpDestDir')
-  var destFile = this._tmpDestDir + '/' + this.outputFile
-  mkdirp.sync(path.dirname(destFile))
-  return mapSeries(this.sourceTrees, readTree)
-    .then(function (includePaths) {
-      var stylusOptions = {
-        filename: includePathSearcher.findFileSync(self.inputFile, includePaths),
-        paths: includePaths,
+StylusCompiler.prototype.updateCache = function (includePaths, cacheDir) {
+  var data;
+  var stylusOptions = {
+    filename: includePathSearcher.findFileSync(this.inputFile, includePaths),
+    paths: includePaths,
+  };
+  _.merge(stylusOptions, this.stylusOptions);
+  stylusOptions.paths = [path.dirname(stylusOptions.filename)].concat(stylusOptions.paths);
+  data = fs.readFileSync(stylusOptions.filename, 'utf8');
+
+  var destFile = cacheDir + this.outputFile;
+  var promise = new RSVP.Promise(function(resolve, reject) {
+    stylus.render(data, stylusOptions, function (e, css) {
+      if (e) {
+        reject(e);
       }
-      _.merge(stylusOptions, self.stylusOptions)
-      stylusOptions.paths = [path.dirname(stylusOptions.filename)].concat(stylusOptions.paths);
-      data = fs.readFileSync(stylusOptions.filename, 'utf8');
+      mkdirp.sync(path.dirname(destFile));
+      fs.writeFileSync(destFile, css, { encoding: 'utf8' });
 
-      var promise = new RSVP.Promise(function(resolve, reject) {
-        stylus.render(data, stylusOptions, function (e, css) {
-          if (e) {
-            reject(e);
-          }
-          fs.writeFileSync(destFile, css, { encoding: 'utf8' });
-
-          resolve(self._tmpDestDir);
-        });
-      });
-
-      return promise;
+      resolve();
     });
-}
+  });
 
-StylusCompiler.prototype.cleanup = function () {
-  quickTemp.remove(this, '_tmpDestDir')
-}
+  return promise;
+};
 

--- a/package.json
+++ b/package.json
@@ -25,11 +25,10 @@
   ],
   "dependencies": {
     "codependency": "^0.1.3",
+    "broccoli-caching-writer": "^0.5.1",
     "include-path-searcher": "^0.1.0",
     "lodash": "~2.4.1",
     "mkdirp": "^0.3.5",
-    "promise-map-series": "^0.2.0",
-    "quick-temp": "^0.1.0",
     "rsvp": "~3.0.6",
     "stylus": "~0.49.0"
   },


### PR DESCRIPTION
This borrows heavily from [broccoli-caching-writer](https://github.com/rwjblue/broccoli-caching-writer) to perform caching of builds. I tried to figure out how to inherit from `broccoli-caching-writer`, but it is either extremely difficult or impossible, since `broccoli-caching-writer` does not allow multiple source trees.

Now stylus compilation will only be invoked if there are actually changes to the file system for the input trees. Otherwise, the last cached build will be used.
