### PR TITLE
Correctly use custom Stylus version if available

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,9 +4,14 @@ var mkdirp = require('mkdirp')
 var includePathSearcher = require('include-path-searcher')
 var quickTemp = require('quick-temp')
 var mapSeries = require('promise-map-series')
-var stylus = require('stylus')
 var _ = require('lodash')
 var RSVP = require('rsvp');
+
+// Use the stylus module in the root project if available;
+// otherwise, use the one included with this plugin
+var codependency = require('codependency');
+var requirePeer = codependency.register(module, { index: ['peerDependencies'] });
+var stylus = requirePeer('stylus', { optional: true }) || require('stylus');
 
 module.exports = StylusCompiler
 function StylusCompiler (sourceTrees, inputFile, outputFile, options) {

--- a/package.json
+++ b/package.json
@@ -24,13 +24,14 @@
     "css"
   ],
   "dependencies": {
-    "mkdirp": "^0.3.5",
-    "lodash": "~2.4.1",
-    "quick-temp": "^0.1.0",
-    "promise-map-series": "^0.2.0",
+    "codependency": "^0.1.3",
     "include-path-searcher": "^0.1.0",
-    "stylus": "~0.48.1",
-    "rsvp": "~3.0.6"
+    "lodash": "~2.4.1",
+    "mkdirp": "^0.3.5",
+    "promise-map-series": "^0.2.0",
+    "quick-temp": "^0.1.0",
+    "rsvp": "~3.0.6",
+    "stylus": "~0.48.1"
   },
   "peerDependencies": {
     "stylus": "*"


### PR DESCRIPTION
[Per the README](https://github.com/gabrielgrant/broccoli-stylus-single#stylus-version) the Stylus version used by this plugin should be configurable.

`peerDependencies` doesn't appear to work in the way that I had expected it to.

This change will check for `stylus` in the root project and fall back to the version included as a dependency of `broccoli-stylus-single` if it's not present.
